### PR TITLE
Updated the dependencies to eslint 3, promise 2 and standard 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "eslint-config-emakinacee",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "eslint config for emakina cee",
   "main": "index.js",
   "author": "Thomas Peklak",
   "license": "MIT",
   "repository": "git@github.com:the-diamond-dogs-group-oss/eslint-config-emakinacee.git",
   "peerDependencies": {
-    "eslint": "^2.5.3",
-    "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.2",
-    "eslint-plugin-angular": "^1.0.0"
+    "eslint": "^3.1.1",
+    "eslint-plugin-promise": "^2.0.0",
+    "eslint-plugin-standard": "^2.0.0",
+    "eslint-plugin-angular": "^1.3.0"
   }
 }


### PR DESCRIPTION
This fixes some npm errors when using the latest versions of eslint and plugins
